### PR TITLE
feat: Add wait for healthy options to CreateDeploymentOptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.99"
-atlas-local = { git = "https://github.com/mongodb/atlas-local-lib.git", rev = "323a879b8385e8e572f8545e3273fafa5698f8c6" }
+atlas-local = { git = "https://github.com/mongodb/atlas-local-lib.git", rev = "fa7cb7aa67e9169f48864a81f3b63f1cf35c81bb" }
 bollard = "0.19.2"
 napi = { version = "3.0.0", features = ["async", "anyhow"] }
 napi-derive = "3.0.0"

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,8 @@ export interface CreateDeploymentOptions {
   name?: string
   image?: string
   mongodbVersion?: string
+  waitUntilHealthy?: boolean
+  waitUntilHealthyTimeout?: number
   creationSource?: CreationSource
   localSeedLocation?: string
   mongodbInitdbDatabase?: string


### PR DESCRIPTION
# Description
Jira ticket: [MCP-194](https://jira.mongodb.org/browse/MCP-194)

## Main change
- Added two options to the create deployment options
  - wait_until_healthy: Bool flag for feature 
  - wait_until_healthy_timeout: Timeout duration for feature in seconds   


## Flyby
