### PR TITLE
chore: remove mongodb from exclude list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.99"
-atlas-local = { git = "https://github.com/mongodb/atlas-local-lib.git", rev = "f874fe90553e5158034aea0587669f0e8ac75127" }
+atlas-local = { git = "https://github.com/mongodb/atlas-local-lib.git", rev = "0cc744d3af8b39c5db674d6d8d227c1f453536b5" }
 bollard = "0.19.2"
 napi = { version = "^3.3.0", features = ["async", "anyhow"] }
 napi-derive = "^3.2.5"

--- a/deny.toml
+++ b/deny.toml
@@ -38,7 +38,7 @@ targets = [
 # they are connected to another crate in the graph that hasn't been pruned,
 # so it should be used with care. The identifiers are [Package ID Specifications]
 # (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
-exclude = ["mongodb"]
+exclude = []
 # If true, metadata will be collected with `--all-features`. Note that this can't
 # be toggled off if true, if you want to conditionally enable `--all-features` it
 # is recommended to pass `--all-features` on the cmd line instead


### PR DESCRIPTION
# Changes
- Updated the `atlas-local` lib, which removes the `mongodb` dependency
- Removed `mongodb` from the exclude list


Jira: [\[MCP-230\] \[atlas-local-js\] remove mongo from deny.toml](https://jira.mongodb.org/browse/MCP-230)