### PR TITLE
fix: Use latest changes in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --tag v${{ needs.update-version.outputs.version }} --unreleased
+          args: --latest
         env:
           OUTPUT: RELEASE_NOTES.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
Since the release notes generation occurs after the release commit, use --latest rather than --unreleased