### PR TITLE
ci: include version number in release workflow run name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
         required: true
         type: string
 
+run-name: "Release: ${{ inputs.version }}"
+
 env:
   DEBUG: napi:*
   APP_NAME: atlas-local


### PR DESCRIPTION
Right now all our releases runs have the title `Release`, after this change the title will be `Release: [version number]`