### PR TITLE
feat: export enums as string unions instead of enums

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,11 +10,9 @@ export declare class Client {
   getDeploymentId(clusterIdOrName: string): Promise<string>
 }
 
-export declare const enum BindingType {
-  Loopback = 'Loopback',
-  AnyInterface = 'AnyInterface',
-  Specific = 'Specific'
-}
+export type BindingType =  'Loopback'|
+'AnyInterface'|
+'Specific';
 
 export interface CreateDeploymentOptions {
   name?: string
@@ -41,12 +39,10 @@ export interface CreationSource {
   source: string
 }
 
-export declare const enum CreationSourceType {
-  AtlasCLI = 'AtlasCLI',
-  Container = 'Container',
-  MCPServer = 'MCPServer',
-  Other = 'Other'
-}
+export type CreationSourceType =  'AtlasCLI'|
+'Container'|
+'MCPServer'|
+'Other';
 
 export interface Deployment {
   containerId: string
@@ -74,17 +70,13 @@ export interface MongoDbPortBinding {
   port?: number
 }
 
-export declare const enum MongodbType {
-  Community = 'Community',
-  Enterprise = 'Enterprise'
-}
+export type MongodbType =  'Community'|
+'Enterprise';
 
-export declare const enum State {
-  Created = 'Created',
-  Dead = 'Dead',
-  Exited = 'Exited',
-  Paused = 'Paused',
-  Removing = 'Removing',
-  Restarting = 'Restarting',
-  Running = 'Running'
-}
+export type State =  'Created'|
+'Dead'|
+'Exited'|
+'Paused'|
+'Removing'|
+'Restarting'|
+'Running';

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "scripts": {
     "artifacts": "napi artifacts",
     "bench": "node --import @oxc-node/core/register benchmark/bench.ts",
-    "build": "napi build --platform --release",
-    "build:debug": "napi build --platform",
+    "build": "napi build --platform --release --no-const-enum",
+    "build:debug": "napi build --platform --no-const-enum",
     "format": "run-p format:prettier format:rs format:toml",
     "format:prettier": "prettier . -w",
     "format:toml": "taplo format",


### PR DESCRIPTION
Configure napi to generate string unions instead of enums for rust enums.

Solves: https://github.com/mongodb-js/mongodb-mcp-server/pull/632#discussion_r2419849225