### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mongodb-js/apix-devtools


### PR DESCRIPTION
## Summary
Adds CODEOWNERS to assign the apix-devtools team as default code owner.

## Notes
The apix-devtools team already has access to this repository.