### PR TITLE
ci: use pull_request_target for dependabot auto-approve workflow

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,6 +1,6 @@
 name: Dependabot Auto-Approve
 
-on: pull_request
+on: pull_request_target
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary

- Change trigger from `pull_request` to `pull_request_target` for the Dependabot auto-approve workflow
- `pull_request_target` runs the workflow from the base branch (trusted, reviewed code) instead of the PR head
- Has access to repository secrets without requiring them to be duplicated as Dependabot secrets

## Why

`pull_request_target` is the GitHub-recommended pattern for automating Dependabot PRs:
- Workflow definition comes from base branch (not PR branch), preventing malicious workflow modifications
- Secrets are available in the base branch context
- The `dependabot[bot]` author guard ensures only Dependabot PRs trigger the automation

The `actions/checkout` step already correctly specifies `ref: github.event.pull_request.head.ref` to check out the actual PR code for license regeneration.

## Test plan

- [ ] Verify next Dependabot PR triggers `auto-approve` successfully
- [ ] Verify LICENSE-3RD-PARTY.txt gets regenerated and pushed by APIX bot
- [ ] Verify PR gets approved and auto-merged when CI is green