### PR TITLE
chore(deps): drop direct bollard dep, use atlas-local 0.7.1 factory methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "atlas-local"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b822617b3d33f3b82308f74d47a967322f58393f266645841617e9984c341ede"
+checksum = "679cd28955e6e4c120b01d225f0b60f686ca50536e21dfd8232750d25cad98fb"
 dependencies = [
  "bollard",
  "bytes",
@@ -31,6 +31,7 @@ dependencies = [
  "maplit",
  "rand",
  "semver",
+ "serde",
  "thiserror",
  "tokio",
  "typed-builder",
@@ -42,7 +43,6 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "atlas-local",
- "bollard",
  "napi",
  "napi-build",
  "napi-derive",
@@ -75,9 +75,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bollard"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227aa051deec8d16bd9c34605e7aaf153f240e35483dd42f6f78903847934738"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
 dependencies = [
  "base64",
  "bollard-stubs",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.52.1-rc.29.1.3"
+version = "1.53.1-rc.29.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
 dependencies = [
  "serde",
  "serde_json",
@@ -650,9 +650,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -690,13 +690,13 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -880,6 +880,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -967,12 +971,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1035,16 +1039,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
  "socket2",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1342,86 +1346,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.102"
-atlas-local = { version = "0.6.1", default-features = false }
-bollard = "0.20.1"
+atlas-local = { version = "0.7.1" }
 napi = { version = "^3.9.0", features = ["async", "anyhow"] }
 napi-derive = "^3.5.6"
 

--- a/LICENSE-3RD-PARTY.txt
+++ b/LICENSE-3RD-PARTY.txt
@@ -4,7 +4,7 @@ THIRD PARTY LICENSES
 This file lists the licenses of the projects used in atlas-local-js.
 
 OVERVIEW OF LICENSES:
-- Apache License 2.0 (107 dependencies)
+- Apache License 2.0 (97 dependencies)
 - MIT License (24 dependencies)
 - Unicode License v3 (19 dependencies)
 - ISC License (1 dependencies)
@@ -229,17 +229,7 @@ OVERVIEW OF LICENSES:
         - windows-link 0.2.1 (https://github.com/microsoft/windows-rs)
         - windows-result 0.4.1 (https://github.com/microsoft/windows-rs)
         - windows-strings 0.5.1 (https://github.com/microsoft/windows-rs)
-        - windows-sys 0.60.2 (https://github.com/microsoft/windows-rs)
         - windows-sys 0.61.2 (https://github.com/microsoft/windows-rs)
-        - windows-targets 0.53.5 (https://github.com/microsoft/windows-rs)
-        - windows_aarch64_gnullvm 0.53.1 (https://github.com/microsoft/windows-rs)
-        - windows_aarch64_msvc 0.53.1 (https://github.com/microsoft/windows-rs)
-        - windows_i686_gnu 0.53.1 (https://github.com/microsoft/windows-rs)
-        - windows_i686_gnullvm 0.53.1 (https://github.com/microsoft/windows-rs)
-        - windows_i686_msvc 0.53.1 (https://github.com/microsoft/windows-rs)
-        - windows_x86_64_gnu 0.53.1 (https://github.com/microsoft/windows-rs)
-        - windows_x86_64_gnullvm 0.53.1 (https://github.com/microsoft/windows-rs)
-        - windows_x86_64_msvc 0.53.1 (https://github.com/microsoft/windows-rs)
 -----------------------------------------------------------------------------
 
                                  Apache License
@@ -448,7 +438,7 @@ OVERVIEW OF LICENSES:
 -----------------------------------------------------------------------------
                         Apache License 2.0
         applies to: 
-        - bollard 0.20.1 (https://github.com/fussybeaver/bollard)
+        - bollard 0.21.0 (https://github.com/fussybeaver/bollard)
         - hyper-named-pipe 0.1.0 (https://github.com/fussybeaver/hyper-named-pipe)
 -----------------------------------------------------------------------------
 
@@ -659,7 +649,7 @@ OVERVIEW OF LICENSES:
                         Apache License 2.0
         applies to: 
         - atlas_local 1.3.0
-        - atlas-local 0.6.1 (https://github.com/mongodb/atlas-local-lib)
+        - atlas-local 0.7.1 (https://github.com/mongodb/atlas-local-lib)
 -----------------------------------------------------------------------------
 
                                  Apache License
@@ -2154,7 +2144,7 @@ limitations under the License.
         - once_cell 1.21.3 (https://github.com/matklad/once_cell)
         - percent-encoding 2.3.2 (https://github.com/servo/rust-url/)
         - smallvec 1.15.1 (https://github.com/servo/rust-smallvec)
-        - socket2 0.6.2 (https://github.com/rust-lang/socket2)
+        - socket2 0.6.3 (https://github.com/rust-lang/socket2)
         - stable_deref_trait 1.2.1 (https://github.com/storyyeller/stable_deref_trait)
         - typed-builder-macro 0.23.2 (https://github.com/idanarye/rust-typed-builder)
         - typed-builder 0.23.2 (https://github.com/idanarye/rust-typed-builder)
@@ -3408,9 +3398,9 @@ limitations under the License.
         applies to: 
         - android_system_properties 0.1.5 (https://github.com/nical/android_system_properties)
         - anyhow 1.0.102 (https://github.com/dtolnay/anyhow)
-        - bollard-stubs 1.52.1-rc.29.1.3
+        - bollard-stubs 1.53.1-rc.29.3.1
         - itoa 1.0.17 (https://github.com/dtolnay/itoa)
-        - libc 0.2.180 (https://github.com/rust-lang/libc)
+        - libc 0.2.186 (https://github.com/rust-lang/libc)
         - pin-project-lite 0.2.16 (https://github.com/taiki-e/pin-project-lite)
         - proc-macro2 1.0.106 (https://github.com/dtolnay/proc-macro2)
         - quote 1.0.44 (https://github.com/dtolnay/quote)
@@ -3783,7 +3773,7 @@ THIS SOFTWARE.
 -----------------------------------------------------------------------------
                         MIT License
         applies to: 
-        - mio 1.1.1 (https://github.com/tokio-rs/mio)
+        - mio 1.2.0 (https://github.com/tokio-rs/mio)
 -----------------------------------------------------------------------------
 
 Copyright (c) 2014 Carl Lerche and other MIO contributors
@@ -4221,7 +4211,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
                         MIT License
         applies to: 
         - tokio-util 0.7.18 (https://github.com/tokio-rs/tokio)
-        - tokio 1.49.0 (https://github.com/tokio-rs/tokio)
+        - tokio 1.52.3 (https://github.com/tokio-rs/tokio)
 -----------------------------------------------------------------------------
 
 MIT License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 
 use anyhow::{Context, Result};
 use atlas_local::Client as AtlasLocalClient;
-use bollard::Docker;
 use napi_derive::napi;
 
 use crate::models::list_deployments::Deployment;
@@ -18,9 +17,8 @@ pub struct Client {
 impl Client {
   #[napi(factory)]
   pub fn connect() -> Result<Client> {
-    let docker = Docker::connect_with_defaults().context("connect to docker")?;
-
-    let atlas_local_client = AtlasLocalClient::new(docker);
+    let atlas_local_client =
+      AtlasLocalClient::connect_with_defaults().context("connect to docker")?;
 
     Ok(Client {
       client: atlas_local_client,


### PR DESCRIPTION
## Summary

- Bumps `atlas-local` from `0.6.1` to `0.7.1`
- Removes direct `bollard` dependency — now pulled in transitively via `atlas-local`'s `bollard` feature (enabled by default in 0.7.1)
- Replaces manual `Docker::connect_with_defaults()` + `AtlasLocalClient::new(docker)` with `AtlasLocalClient::connect_with_defaults()`

Jira: https://jira.mongodb.org/browse/CLOUDP-407917

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — 13/13 pass
- [x] `cargo fmt` — no changes
- [x] `cargo clippy` — no warnings