### PR TITLE
fix: trust Coveralls Homebrew tap for macOS runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -200,6 +200,9 @@ jobs:
         shell: bash
       - name: Test bindings
         run: yarn test
+      - name: Trust Coveralls tap (macOS)
+        if: runner.os == 'macOS'
+        run: brew tap coverallsapp/coveralls && brew trust coverallsapp/coveralls
       - name: Upload coverage report
         env:
           COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
Homebrew 6.0.0 (released 2026-06-11) requires third-party taps to be explicitly trusted before use. Adds a conditional `brew trust` step before the Coveralls upload on macOS runners.

Ref: https://github.com/coverallsapp/github-action/pull/265